### PR TITLE
Add Twig filter/function integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "phpstan/phpstan": "^1.8",
         "seld/jsonlint": "^1.9",
         "squizlabs/php_codesniffer": "^3.7",
+        "twig/twig": "^3.4",
         "vimeo/psalm": "^4.23"
     },
     "autoload": {

--- a/src/Charcoal/Image/Glide/Bridge/Twig/Extension/GlideExtension.php
+++ b/src/Charcoal/Image/Glide/Bridge/Twig/Extension/GlideExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Charcoal\Image\Glide\Bridge\Twig\Extension;
+
+use Charcoal\Image\Glide\Config\Manipulations;
+use Charcoal\Image\Glide\Manager\GlideManager;
+use Charcoal\Image\Glide\Mixin\GlideManagerTrait;
+use League\Glide\Urls\UrlBuilder;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+/**
+ * Glide Twig Extension
+ */
+class GlideExtension extends AbstractExtension
+{
+    use GlideManagerTrait;
+
+    public function __construct(GlideManager $glideManager)
+    {
+        $this->setGlideManager($glideManager);
+    }
+
+    public function getFilters()
+    {
+        return [
+            // Usage: `{{ 'image.jpg' | glide(server='secondary', width=200, height=200,...) }}`
+            new TwigFilter('glide', [ $this, 'buildRequestUrl' ], [ 'is_variadic' => true ]),
+        ];
+    }
+
+    public function getFunctions()
+    {
+        return [
+            // Usage: `{{ glide('image.jpg', preset='thumbnail',...) }}`
+            new TwigFunction('glide', [ $this, 'buildRequestUrl' ], [ 'is_variadic' => true ]),
+        ];
+    }
+
+    public function buildRequestUrl($path, array $options = [])
+    {
+        $manager = $this->getGlideManager();
+
+        if (isset($options['server'])) {
+            $name = $options['server'];
+            unset($options['server']);
+        } else {
+            $name = $manager->getCurrentServer();
+        }
+
+        $params = Manipulations::convertToGlideParameters($options);
+
+        return $manager->getUrlBuilder($name)->buildRequestUrl($path, $params);
+    }
+}

--- a/src/Charcoal/Image/Glide/Config/Manipulations.php
+++ b/src/Charcoal/Image/Glide/Config/Manipulations.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Charcoal\Image\Glide\Config;
+
+use Charcoal\Image\Glide\Exception\UnknownManipulationException;
+
+/**
+ * Glide Manipulations
+ *
+ * Last updated: 2022-09-21
+ * Supported version: 2.2.2 (2022-02-21)
+ *
+ * {@link https://glide.thephpleague.com/2.0/api/quick-reference/}
+ */
+class Manipulations
+{
+    /**
+     * Map of available custom manipulation names to Glide query parameters.
+     *
+     * @var array<string, string>
+     */
+    public static $api = [
+        // Sorted Glide manipulations
+        'background'        => 'bg',
+        'blur'              => 'blur',
+        'border'            => 'border',
+        'brightness'        => 'bri',
+        'contrast'          => 'con',
+        'crop'              => 'fit',
+        'devicePixelRatio'  => 'dpr',
+        'filter'            => 'filt',
+        'fit'               => 'fit',
+        'flip'              => 'flip',
+        'format'            => 'fm',
+        'gamma'             => 'gam',
+        'height'            => 'h',
+        'manualCrop'        => 'crop',
+        'orientation'       => 'or',
+        'pixelate'          => 'pixel',
+        'quality'           => 'q',
+        'sharpen'           => 'sharp',
+        'watermark'         => 'mark',
+        'watermarkFit'      => 'markfit',
+        'watermarkHeight'   => 'markh',
+        'watermarkOpacity'  => 'markalpha',
+        'watermarkPaddingX' => 'markx',
+        'watermarkPaddingY' => 'marky',
+        'watermarkPosition' => 'markpos',
+        'watermarkWidth'    => 'markw',
+        'width'             => 'w',
+        // Sorted Glide options
+        'preset'            => 'p',
+    ];
+
+    /**
+     * @param  array<(int|string), mixed> $manipulationNames
+     * @return array<(int|string), mixed>
+     */
+    public static function convertToGlideParameters(array $manipulations): array
+    {
+        $glideManipulations = [];
+
+        foreach ($manipulations as $name => $value) {
+            if (is_string($name)) {
+                $name = self::convertToGlideParameter($name);
+                $glideManipulations[$name] = $value;
+            } elseif (is_string($value)) {
+                $value = self::convertToGlideParameter($value);
+                $glideManipulations[] = $value;
+            } else {
+                throw new UnknownManipulationException(
+                    sprintf('Manipulation "%s" is not invalid', $name)
+                );
+            }
+        }
+
+        return $glideManipulations;
+    }
+
+    /**
+     * Converts the given long manipulation name to the short parameter name
+     * if applicable, otherwise returns the given manipulation name.
+     */
+    public static function convertToGlideParameter(string $manipulationName): string
+    {
+        return (self::$api[$manipulationName] ?? $manipulationName);
+    }
+
+    /**
+     * Converts the given long manipulation name to the short parameter name
+     * if applicable, otherwise throws an exception.
+     */
+    public static function convertToGlideParameterOrFail(string $manipulationName): string
+    {
+        if (isset(self::$api[$manipulationName])) {
+            return self::$api[$manipulationName];
+        }
+
+        throw new UnknownManipulationException(
+            sprintf('Manipulation "%s" is not defined', $manipulationName)
+        );
+    }
+}

--- a/src/Charcoal/Image/Glide/Exceptions/UnknownManipulationException.php
+++ b/src/Charcoal/Image/Glide/Exceptions/UnknownManipulationException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Charcoal\Image\Glide\Exceptions;
+
+class UnknownManipulationException extends \RuntimeException implements
+    ExceptionInterface
+{
+}

--- a/src/Charcoal/Image/Glide/Providers/GlideServiceProvider.php
+++ b/src/Charcoal/Image/Glide/Providers/GlideServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Charcoal\Image\Glide\Providers;
 
+use Charcoal\Image\Glide\Bridge\Twig\Extension\GlideExtension as TwigGlideExtension;
 use Charcoal\Image\Glide\Config\GlideConfig;
 use Charcoal\Image\Glide\Factory\ResponseFactoryDiscovery;
 use Charcoal\Image\Glide\Manager\GlideManager;
@@ -38,5 +39,39 @@ class GlideServiceProvider implements ServiceProviderInterface
         };
 
         $container['glide/response/factory'] = fn (): ?ResponseFactoryInterface => ResponseFactoryDiscovery::find();
+
+        $this->registerTwigExtensions($container);
+    }
+
+    /**
+     * Register the contrib's services.
+     *
+     * @param  Container $container The service locator.
+     * @return void
+     */
+    public function registerTwigExtensions(Container $container)
+    {
+        $container['glide/twig/extension'] = function (Container $container): TwigGlideExtension {
+            return new TwigGlideExtension(
+                $container['glide/manager']
+            );
+        };
+
+        if (!isset($container['view/twig/helpers'])) {
+            /**
+             * @return array<\Twig\Extension\ExtensionInterface>
+             */
+            $container['view/twig/helpers'] = fn (): array => [];
+        }
+
+        /**
+         * @param  array<\Twig\Extension\ExtensionInterface> $helpers
+         * @return array<\Twig\Extension\ExtensionInterface>
+         */
+        $container->extend('view/twig/helpers', function (array $helpers, Container $container): array {
+            return array_merge($helpers, [
+                $container['glide/twig/extension'],
+            ]);
+        });
     }
 }


### PR DESCRIPTION
Integrates into `charcoal/view`'s Twig extensions service.

Example:

```twig
<img src="{{ glide('image.jpg', { width: 600 }) }}" />
```

```twig
<img src="{{ 'image.jpg' | glide({ p: 'hero' }) }}" />
```

Todo:

- [ ] Test and refine implementation of extension.
- [ ] Add unit/integration tests.