### PR TITLE
Add Twig tag integration

### DIFF
--- a/src/Charcoal/Image/Glide/Bridge/Twig/Extension/GlideExtension.php
+++ b/src/Charcoal/Image/Glide/Bridge/Twig/Extension/GlideExtension.php
@@ -7,6 +7,7 @@ namespace Charcoal\Image\Glide\Bridge\Twig\Extension;
 use Charcoal\Image\Glide\Config\Manipulations;
 use Charcoal\Image\Glide\Manager\GlideManager;
 use Charcoal\Image\Glide\Mixin\GlideManagerTrait;
+use Charcoal\Image\Glide\Bridge\Twig\TokenParser\GlideTokenParser;
 use League\Glide\Urls\UrlBuilder;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -37,6 +38,14 @@ class GlideExtension extends AbstractExtension
         return [
             // Usage: `{{ glide('image.jpg', preset='thumbnail',...) }}`
             new TwigFunction('glide', [ $this, 'buildRequestUrl' ], [ 'is_variadic' => true ]),
+        ];
+    }
+
+    public function getTokenParsers(): array
+    {
+        return [
+            // Usage: `{% glide path='image.jpg' %}<img src="{{ url }}" width="{{ width }}" height="{{ height }}">{% endglide %}`
+            new GlideTokenParser(),
         ];
     }
 

--- a/src/Charcoal/Image/Glide/Bridge/Twig/Node/GlideNode.php
+++ b/src/Charcoal/Image/Glide/Bridge/Twig/Node/GlideNode.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Charcoal\Image\Glide\Bridge\Twig\Node;
+
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
+
+class GlideNode extends Node
+{
+    public function __construct(
+        AbstractExpression $path,
+        ?AbstractExpression $options,
+        Node $body,
+        int $lineno,
+        string $tag
+    ) {
+        $nodes = [
+            'path' => $key,
+            'body' => $body,
+        ];
+
+        if (null !== $options) {
+            $nodes['options'] = $options;
+        }
+
+        parent::__construct($nodes, [], $lineno, $tag);
+    }
+
+    public function compile(Compiler $compiler): void
+    {
+        $compiler->addDebugInfo($this);
+
+        $parentContextName = $compiler->getVarName();
+
+        $compiler->write(sprintf("\$%s = \$context;\n", $parentContextName));
+
+        $compiler
+            ->write('$cached = $this->env->getRuntime(\'Twig\Extra\Cache\CacheRuntime\')->getCache()->get(')
+            ->subcompile($this->getNode('key'))
+            ->raw(", function (\Symfony\Contracts\Cache\ItemInterface \$item) use (\$context, \$macros) {\n")
+            ->indent();
+
+        if ($this->hasNode('options')) {
+            $node = $this->getNode('options');
+            $varsName = $compiler->getVarName();
+            $compiler
+                ->write(sprintf('$%s = ', $varsName))
+                ->subcompile($node)
+                ->raw(";\n")
+                ->write(sprintf("if (!twig_test_iterable(\$%s)) {\n", $varsName))
+                ->indent()
+                ->write("throw new RuntimeError('Variables passed to the \"with\" tag must be a hash.', ")
+                ->repr($node->getTemplateLine())
+                ->raw(", \$this->getSourceContext());\n")
+                ->outdent()
+                ->write("}\n")
+                ->write(sprintf("\$%s = twig_to_array(\$%s);\n", $varsName, $varsName))
+            ;
+
+            if ($this->getAttribute('only')) {
+                $compiler->write("\$context = [];\n");
+            }
+
+            $compiler->write(sprintf("\$context = \$this->env->mergeGlobals(array_merge(\$context, \$%s));\n", $varsName));
+        }
+
+        $compiler
+            ->subcompile($this->getNode('body'))
+            ->write(sprintf("\$context = \$%s;\n", $parentContextName));
+        ;
+    }
+}

--- a/src/Charcoal/Image/Glide/Bridge/Twig/TokenParser/GlideTokenParser.php
+++ b/src/Charcoal/Image/Glide/Bridge/Twig/TokenParser/GlideTokenParser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Charcoal\Image\Glide\Bridge\Twig\TokenParser;
+
+use Charcoal\Image\Glide\Bridge\Twig\Node\GlideNode;
+use Twig\Node\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+/**
+ * Token parser for the 'glide' tag
+ *
+ * ```twig
+ * {% glide 'image.jpg' { width: 200 } %}
+ *     <img src="{{ url }}" width="{{ width }}" height="{{ height }}">
+ * {% endglide %}
+ * ```
+ */
+class GlideTokenParser extends AbstractTokenParser
+{
+    public function parse(Token $token): Node
+    {
+        $stream = $this->parser->getStream();
+
+        $path    = $stream->expect(Token::NAME_TYPE)->getValue();
+        $options = $this->parser->getExpressionParser()->parseExpression();
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        $body = $this->parser->subparse([$this, 'decideGlideEnd'], true);
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        return new GlideNode($path, $options, $body, $token->getLine(), $this->getTag());
+    }
+
+    public function decideGlideEnd(Token $token): bool
+    {
+        return $token->test('endglide');
+    }
+
+    public function getTag(): string
+    {
+        return 'glide';
+    }
+}


### PR DESCRIPTION
Extends Twig extension introduced in #2.

Example:

```twig
{% glide 'image.jpg' { w: 600 } %}
    <img src="{{ url }}" width="{{ width }}" height="{{ height }}">
{% endglide %}
```

Todo:

- [ ] Finish implementation of custom token parser and custom node.
- [ ] Test and refine implementation of tag.
- [ ] Add unit/integration tests.